### PR TITLE
minor edits to clarify examples and to reduce uses of terms like tidy or repository

### DIFF
--- a/docs/source/format/hub-structure.md
+++ b/docs/source/format/hub-structure.md
@@ -1,9 +1,9 @@
 (hub-structure)=
 # Structure of Hub repositories
 
-A Hub should be structured according to the following recommendations. 
+A Hub should be structured according to the following recommendations.  
 
-Generally, the Hub repository is intended primarily as a storage space for primary data. All other code and outputs related to model output validation, visualizations, reports, ensemble construction, etc., should be placed in repositories other than the primary Hub repository.
+Generally, Hub file structure is intended primarily as a storage space for primary data. All other code and outputs related to model output validation, visualizations, reports, ensemble construction, etc., should be placed in repositories other than the primary Hub location.
 
 The directory and file structure of a modeling hub should contain only the following directories and files:
 
@@ -22,5 +22,7 @@ The directory and file structure of a modeling hub should contain only the follo
 
 * `auxiliary-data` (optional, see {doc}`/format/target-data`)
 
-* Optionally, any files necessary to define continuous integration workflows, for example for the purpose of validating submissions or updating target data. To the extent possible, only the workflow definition files should be stored within the Hub repository, with any additional scripts or functionality residing in an external repository.
+* Optionally, any files necessary to define continuous integration workflows, for example for the purpose of validating submissions or updating target data. To the extent possible, only the workflow definition files should be stored within the Hub file space, with any additional scripts or functionality residing in an external location.
+
+Although most hubs to date have been housed in GitHub repositories, the proposed structure is more general and can be adapted for use on any shared filesystem. 
 

--- a/docs/source/format/intro-data-formats.md
+++ b/docs/source/format/intro-data-formats.md
@@ -33,7 +33,7 @@ This Hub allows for submissions on a pre-specified set of dates specified by the
 * `target` (the sole **target key** variable): can only take the value "wk inc flu hosp" 
 * `location`: “US”, “01”, “02”, …, “78” ([FIPS codes](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards) for US states and territories)
 * `origin_date` (this variable is specified as the one from which rounds are given IDs): weekly on Mondays
-* `horizon`: 1, 2, 3, 4
+* `horizon`: 1, 2, 3, 4 (in units of weeks, which is specified in the target-metadata)
 ```
 
 

--- a/docs/source/format/model-output.md
+++ b/docs/source/format/model-output.md
@@ -14,7 +14,7 @@ The `model-output` directory in a modeling hub is required to have the following
 
 
 ## Formats of model output
-Model outputs are contributed by teams, and are represented in a “tidy” rectangular format, where each row corresponds to a unique model output and columns define: (1) the model task, (2) specification of the representation of the model output, and (3) the model output value. More detail about each of these is given in the following points:
+Model outputs are contributed by teams, and are represented in a rectangular format, where each row corresponds to a unique model output and columns define: (1) the model task, (2) specification of the representation of the model output, and (3) the model output value. More detail about each of these is given in the following points:
 
 * Task ids: A set of columns specifying the model task, as described [here](task_id_vars). The columns used as task ids will vary across different Hubs.
 

--- a/docs/source/format/target-data.md
+++ b/docs/source/format/target-data.md
@@ -41,7 +41,7 @@ To allow for reproducible analyses in the event of revisions to previously repor
 
 
 ## Calculating modeling targets
-For any modeling Hubs with targets that can be calculated from the truth data, functions should be specified that map time series truth data in the tidy format discussed above to a value of the modeling target for each unique combination of values in the [“task id” columns](task-id-vars). This function should produce data in a tidy format with columns for all task id variables and a value column. These outputs can be consumed by later tools in our pipeline, such as evaluation tools.
+For any modeling Hubs with targets that can be calculated from the truth data, functions should be specified that map time series truth data in the tabular format discussed above to a value of the modeling target for each unique combination of values in the [“task id” columns](task-id-vars). This function should produce data in a tabular format with columns for all task id variables and a value column. These outputs can be consumed by later tools in our pipeline, such as evaluation tools.
 
 
 We illustrate with our second running example: a hypothetical forecasting exercise for influenza hospitalization rates per 100,000 population by age group at the state level in the US, with short-term incidence and “seasonal” targets. Forecasts are requested for each combination of the following variables:

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -24,7 +24,7 @@ We have created some [example Hub repositories](https://github.com/Infectious-Di
 
 ### Schema files for hub configuration
 
-To take advantage of the infrastructure designed by the Consortium, a repository must contain JSON configuration files in a [specific location and format](hub-metadata). The schemas that define the structure and formats of the configuration files live in their own [schemas repository](https://github.com/Infectious-Disease-Modeling-Hubs/schemas). The schemas are versioned, and every hub must point to a specific version of the schemas that they are using.
+To take advantage of the infrastructure designed by the Consortium, a hub must contain JSON configuration files in a [specific location and format](hub-metadata). The schemas that define the structure and formats of the configuration files live in their own [schemas repository](https://github.com/Infectious-Disease-Modeling-Hubs/schemas). The schemas are versioned, and every hub must point to a specific version of the schemas that they are using.
 
 ## Software for modeling hubs
 


### PR DESCRIPTION
Minor changes

1. modified the first example on the overview page to indicate time horizon in weeks.

2. changed model-ouptut and target-data to minimize the use of the terms "tidy" and "repository" so as to not sound too platform/language dependent.