### PR TITLE
Add target metadata table 

### DIFF
--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -84,7 +84,7 @@ It is composed of the following fields:
 * `time_unit`: the units of the time steps in terms of day, week, or month.
 
 ### Example
-Here is an example of how the target metadata fields might appear in the `tasks.json schema` for a Hub whose target is incident covid hospitalizations. 
+Here is an example of how the target metadata fields might appear in the `tasks.json` schema for a Hub whose target is incident covid hospitalizations. 
 
 ```
  "target_metadata": [

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -68,14 +68,14 @@ It is composed of the following fields:
 * `target_units`: the unit of observation used for this target. 
 * `target_keys`: a set of one or more name/value pairs that must match a target defined in the `task_ids` section of the schema. Each value, or the combination of values if multiple keys are specified, defines a single target value.
 * `description`: a verbose explanation of the target, which might include details on the measure used for the target or a definition of 'rate', for example. 
-* `target_type`: the target’s statistical data type. The following table lists the possible values for `target_type` and the `output_type` with which they can be used. 
+* `target_type`: the target’s statistical data type. The following table lists the possible values for `target_type` and the `output_type` with which they can be used. We note that for the binary data type row, mean and median `output_type` are X'ed for definitional consistency, but in practice the hubverse recommends using pmf or sample `output_type` as a more natural way to represent these values.
 
 | `target_type` | mean | median | quantile | cdf   | pmf   | sample 
 |--------- | ----------- |----------- | ----------- |----------- |----------- |----------- |
 | continous | X | X | X | X | - | X |
 | discrete | X | X | X | X | X | X |
 | nominal | - | - | - | - | X | X |
-| binary | - | X | - | - | X | X |
+| binary | X | X | - | - | X | X |
 | date | X | X | X | X | X | X |
 | ordinal | - | X | X | X | X | X |
 | compositional | X | X | - | - | - | X |

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -84,14 +84,22 @@ It is composed of the following fields:
 * `time_unit`: the units of the time steps in terms of day, week, or month.
 
 ### Example
-Here is an example of a Hub that uses incident covid hospitalizations as a target. 
-| field |	value
-|--------- | ----------- |
-| `target_id` |	inc covid hosp
-| `target_name` |	Daily incident COVID hospitalizations
-| `target_units` |	count
-| `target_keys`	| inc covid hosp
-| `description` |	Daily newly reported hospitalizations where the patient has COVID, as reported by hospital facilities and aggregated in the HHS Protect data collection system
-| `target_type` |	discrete
-| `is_step_ahead` |	true
-| `time_unit` |	day
+Here is an example of how the target metadata fields might appear in the `tasks.json schema` for a Hub whose target is incident covid hospitalizations. 
+
+```
+ "target_metadata": [
+                    {
+                       "target_id": "inc covid hosp",
+                       "target_name": "Daily incident COVID hospitalizations",
+                       "target_units": "count",
+                       "target_keys": {
+                           "target": "inc covid hosp"
+                       },
+                       "description": "Daily newly reported hospitalizations where the patient has COVID, as reported by hospital facilities and aggregated in the HHS Protect data collection system.",
+                       "target_type": "discrete",
+                       "is_step_ahead": true,
+                       "time_unit": "day"
+                    }
+                ]
+```
+

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -60,13 +60,13 @@ The [output_type](output_types) object defines accepted representations for each
 (target_metadata)=
 ## Target metadata
 
-Target metadata is an array of objects that defines the characteristics of each target.
+Target metadata is an array in the tasks.json schema file that defines the characteristics of each target.
 
 It is composed of the following fields:
 * `target_id`: a short description that uniquely identifies the target.
 * `target_name`: a longer, human readable description of the target, which could be used as a visualization axis label.
 * `target_units`: the unit of observation used for this target. 
-* `target_keys`: a value that must match a target set in `task_ids`, to appropriately identify it. Each property should have one specified value. Each value, or the combination of values if multiple keys are specified, defines a single target value. The value should be null in the case where the target is not specified as a `task_id` and is specified solely through the `target_id` `target_metadata` property. 
+* `target_keys`: a set of one or more name/value pairs that must match a target defined in the `task_ids` section of the schema. Each value, or the combination of values if multiple keys are specified, defines a single target value.
 * `description`: a verbose explanation of the target, which might include details on the measure used for the target or a definition of 'rate', for example. 
 * `target_type`: the target’s statistical data type. The following table lists the possible values for `target_type` and the `output_type` with which they can be used. 
 

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -60,12 +60,14 @@ The [output_type](output_types) object defines accepted representations for each
 (target_metadata)=
 ## Target metadata
 
-| `Output_type` | `Target_type` |
-| ----------- | ----------- |
-| Mean | String, double, integer |
-| Median | String, double, integer |
-| Quantile | String, double, integer |
-| cdf | Cumulative distribution function values |
-| pmf | Probability mass function values |
-| Sample | String, double, integer |
+The following table lists the possible values for `target_type` and the `output_type` with which they can be used. 
 
+| `Target_type` | Mean | Median | Quantile | Cdf   | Pmf   | Sample 
+|--------- | ----------- |----------- | ----------- |----------- |----------- |----------- |
+| Continous | X | X | X | X | X | X |
+| Discrete | X | X | X | X | X | X |
+| Nominal | - | - | - | - | X | X |
+| Binary | - | X | - | - | X | X |
+| Date | X | X | X | X | X | X |
+| Ordinal | - | X | X | X | X | X |
+| Compositional | X | X | - | - | - | X |

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -60,4 +60,12 @@ The [output_type](output_types) object defines accepted representations for each
 (target_metadata)=
 ## Target metadata
 
-Document here the properties of a target, as listed in the schema.
+| `Output_type` | `Target_type` |
+| ----------- | ----------- |
+| Mean | String, double, integer |
+| Median | String, double, integer |
+| Quantile | String, double, integer |
+| cdf | Cumulative distribution function values |
+| pmf | Probability mass function values |
+| Sample | String, double, integer |
+

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -60,7 +60,7 @@ The [output_type](output_types) object defines accepted representations for each
 (target_metadata)=
 ## Target metadata
 
-Target metadata is an array of objects that defines the characteristics of each target
+Target metadata is an array of objects that defines the characteristics of each target.
 
 It is composed of the following fields:
 * `target_id`: a short description that uniquely identifies the target.

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -60,14 +60,38 @@ The [output_type](output_types) object defines accepted representations for each
 (target_metadata)=
 ## Target metadata
 
-The following table lists the possible values for `target_type` and the `output_type` with which they can be used. 
+Target metadata is an array of objects that defines the characteristics of each target
 
-| `Target_type` | Mean | Median | Quantile | Cdf   | Pmf   | Sample 
+It is composed of the following fields:
+* `target_id`: a short description that uniquely identifies the target.
+* `target_name`: a longer, human readable description of the target, which could be used as a visualization axis label.
+* `target_units`: the unit of observation used for this target. 
+* `target_keys`: a value that must match a target set in `task_ids`, to appropriately identify it. Each property should have one specified value. Each value, or the combination of values if multiple keys are specified, defines a single target value. The value should be null in the case where the target is not specified as a `task_id` and is specified solely through the `target_id` `target_metadata` property. 
+* `description`: a verbose explanation of the target, which might include details on the measure used for the target or a definition of 'rate', for example. 
+* `target_type`: the target’s statistical data type. The following table lists the possible values for `target_type` and the `output_type` with which they can be used. 
+
+| `target_type` | mean | median | quantile | cdf   | pmf   | sample 
 |--------- | ----------- |----------- | ----------- |----------- |----------- |----------- |
-| Continous | X | X | X | X | X | X |
-| Discrete | X | X | X | X | X | X |
-| Nominal | - | - | - | - | X | X |
-| Binary | - | X | - | - | X | X |
-| Date | X | X | X | X | X | X |
-| Ordinal | - | X | X | X | X | X |
-| Compositional | X | X | - | - | - | X |
+| continous | X | X | X | X | - | X |
+| discrete | X | X | X | X | X | X |
+| nominal | - | - | - | - | X | X |
+| binary | - | X | - | - | X | X |
+| date | X | X | X | X | X | X |
+| ordinal | - | X | X | X | X | X |
+| compositional | X | X | - | - | - | X |
+
+* `is_step_ahead`: a Boolean value that indicates whether the target is part of a sequence of values. If `is_step_ahead` is true, then this field is required and defines the unit of time steps. If `is_step_ahead` is false, then this should be left out and/or will be ignored if present.
+* `time_unit`: the units of the time steps in terms of day, week, or month.
+
+### Example
+Here is an example of a Hub that uses incident covid hospitalizations as a target. 
+| field |	value
+|--------- | ----------- |
+| `target_id` |	inc covid hosp
+| `target_name` |	Daily incident COVID hospitalizations
+| `target_units` |	count
+| `target_keys`	| inc covid hosp
+| `description` |	Daily newly reported hospitalizations where the patient has COVID, as reported by hospital facilities and aggregated in the HHS Protect data collection system
+| `target_type` |	discrete
+| `is_step_ahead` |	true
+| `time_unit` |	day

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -60,7 +60,7 @@ The [output_type](output_types) object defines accepted representations for each
 (target_metadata)=
 ## Target metadata
 
-Target metadata is an array in the tasks.json schema file that defines the characteristics of each target.
+Target metadata is an array in the [tasks.json](https://hubdocs.readthedocs.io/en/latest/user-guide/hub-config.html#hub-model-task-configuration-tasks-json-file) schema file that defines the characteristics of each target.
 
 It is composed of the following fields:
 * `target_id`: a short description that uniquely identifies the target.


### PR DESCRIPTION
@elray1 In response to issue #98 , spoke with @nickreich and added a target metadata table, which also incorporates information from Zoltar (https://docs.zoltardata.com/targets/#valid-prediction-types-by-target-type). 