### PR TITLE
Add note about accepted compression ext prefixes

### DIFF
--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -13,6 +13,8 @@ The `model-output` directory in a modeling hub is required to have the following
      
 where `model_id` = `team_abbr-model_abbr`
 
+Note that file names are also allowed to contain the following compression extension prefixes: .snappy, .gzip, .gz, .brotli, .zstd, .lz4, .lzo, .bz2, e.g. `<round-id1>-<model_id>.gz.parquet`.
+
 (model-output-format)=
 ## Formats of model output
 Model outputs are contributed by teams, and are represented in a rectangular format, where each row corresponds to a unique model output and columns define: (1) the model task, (2) specification of the representation of the model output, and (3) the model output value. More detail about each of these is given in the following points:


### PR DESCRIPTION
File names are now allowed to contain the following compression extension prefixes: .snappy, .gzip, .gz, .brotli, .zstd, .lz4, .lzo, .bz2. This PR adds a note about that to make users/hubAdmins aware